### PR TITLE
Collect test candidates eagerly

### DIFF
--- a/src/main/clojure/org/ajoberstar/jovial/engine.clj
+++ b/src/main/clojure/org/ajoberstar/jovial/engine.clj
@@ -128,13 +128,7 @@
 (defn select [^EngineDiscoveryRequest request ^UniqueId id]
   (let [listener (.getDiscoveryListener request)
         selectors (.getSelectorsByType request DiscoverySelector)]
-    (loop [result []
-           head (first selectors)
-           tail (rest selectors)]
-      (let [candidates (try-select listener id head)]
-        (if (seq tail)
-          (recur (concat result candidates) (first tail) (rest tail))
-          (concat result candidates))))))
+    (reduce #(into %1 (try-select listener id %2)) [] selectors)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Discovery Descriptor Support


### PR DESCRIPTION
`concat` produces a lazy sequence, which makes its repeated usage in a
loop a potential stack overflow hazard (when the produced seq gets
realized and has to recur over its subseqs).

Background: I've been trying to introduce clojure to a java/kotlin project. Clojure tests kept on dying with a `StackOverflowError` in CI during test discovery, with stacktrace mentioning `concat`. I couldn't debug the issue very well - it wasn't reliably reproducible locally - but noticed that apparently all AOTted classes in test classpath were being scanned for tests, which is a lot of classes. I've run grep on `jovial`, found a single use of `concat` in a loop and tried to replace it with a non-lazy equivalent. Tests run fine with the patched version. I'm not 100% convinced that `concat`'s laziness was the sole culprit due to flakiness of local test runs, but if it helps it helps.