### PR TITLE
Collect candidates eagerly

### DIFF
--- a/src/main/clojure/dev/clojurephant/jovial/engine.clj
+++ b/src/main/clojure/dev/clojurephant/jovial/engine.clj
@@ -128,13 +128,7 @@
 (defn select [^EngineDiscoveryRequest request ^UniqueId id]
   (let [listener (.getDiscoveryListener request)
         selectors (.getSelectorsByType request DiscoverySelector)]
-    (loop [result []
-           head (first selectors)
-           tail (rest selectors)]
-      (let [candidates (try-select listener id head)]
-        (if (seq tail)
-          (recur (concat result candidates) (first tail) (rest tail))
-          (concat result candidates))))))
+    (reduce #(into %1 (try-select listener id %2)) [] selectors)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Discovery Descriptor Support


### PR DESCRIPTION
Cherry pick of @mpevnev's change in #18 due to a merge conflict (that I caused).

Original comment:

> `concat` produces a lazy sequence, which makes its repeated usage in a loop a potential stack overflow hazard (when the produced seq gets realized and has to recur over its subseqs).
